### PR TITLE
Update GitLab CI/CD script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ before_script:
 validate_doc:
   stage: test
   script:
-    - npm exec -- bump deploy --dry-run bump.openapi.v3.yml
+    - npm exec -- bump deploy --dry-run "bump.openapi.v3.yml" --doc "$BUMP_ID" --token "$BUMP_TOKEN"
   only:
     - branches
   except:
@@ -37,14 +37,14 @@ validate_doc:
 deploy_doc:
   stage: deploy
   script:
-    - npm exec -- bump deploy bump.openapi.v3.yml
+    - npm exec -- bump deploy "bump.openapi.v3.yml" --doc "$BUMP_ID" --token "$BUMP_TOKEN"
   only:
     - main
 
 diff_doc:
   stage: test
   script:
-    - ./.gitlab/diff-comment-mr.sh bump.openapi.v3.yml
+    - sh ./.gitlab/diff-comment-mr.sh "bump.openapi.v3.yml" "$BUMP_ID" "$BUMP_TOKEN"
   only:
     - merge_requests
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,14 +22,14 @@ validate_doc:
   only:
     - branches
   except:
-    - master
+    - main
 
 deploy_doc:
   stage: deploy
   script:
     - npm exec -- bump deploy bump.openapi.v3.yml
   only:
-    - master
+    - main
 
 diff_doc:
   stage: test
@@ -38,4 +38,4 @@ diff_doc:
   only:
     - merge_requests
   except:
-    - master
+    - main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,18 @@
-image: node:15
+image: node:18
 
 stages:
   - test
   - deploy
+
+# About installation of bump-cli as node package.
+# Script here assume that node package 'bump-cli' has previously beeing installed,
+# and is available in package.json (More information about our CLI: https://github.com/bump-sh/cli)
+
+# You can also let npm install the package itself:
+# In this case, script here can be adapted:
+# - 'cache' and 'before_script' can be removed
+# - remplace every call to 'bump' package by 'bump-cli', for example:
+# - npm exec -- bump-cli deploy --dry-run 'path/to/your/file' for validation
 
 cache:
   key:

--- a/.gitlab/diff-comment-mr.sh
+++ b/.gitlab/diff-comment-mr.sh
@@ -5,7 +5,7 @@
 # - 2. The bump slug (`BUMP_ID`)
 # - 3. The Bump token (`BUMP_TOKEN`)
 #
-# Usage: ./diff-comment-mr.sh doc/openapi.yml my-doc my-bump-token-123
+# Usage: ./diff-comment-mr.sh "doc/openapi.yml" "bump_documentation_slug" "bump_token"
 #
 
 bump_preview() {


### PR DESCRIPTION
Some suggestions noticed by testing the script on a [test repository on GitLab](https://gitlab.com/Polo2/restaurant-api):

- Update node to last version (15 -> 18)
- Mention how to run CI/CD script without installing `bump-cli` package in 'package.json'
- Replace default private branch (master -> main)
- Complete calls to CLI: add parameters slug, token, and favor single quotes (or it crashs, cf [this job](https://gitlab.com/Polo2/restaurant-api/-/jobs/7061347968) )
- Use `sh` to call  'diff-comment-mr.sh' and thus override  execution rights missing (or it crashes, cf [this job](https://gitlab.com/Polo2/restaurant-api/-/jobs/7061216546) )